### PR TITLE
Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ To compile the tool on Linux, use the following command:
 # How to Use:
 
 Run the converter by providing the path to a TEX file:
-`./tex2dds path_to_texture.tex`
+tex2dds input_texture.tex [OPTIONS]
+
+Options:
+  -o, --output <output_file.dds>  Specify the output DDS file path and name
+  -h, --help                      Show this help message and exit
 
 
 # Credits:


### PR DESCRIPTION
-o/--output option: You can specify the output DDS file path and name. If not provided, the output file is generated by replacing the .tex extension of the input file with .dds.

-h/--help option: Displays a help message with usage instructions.

Error handling for incorrect or missing arguments and file operations (input/output file issues).